### PR TITLE
Fixes XMPP response

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ class XMPPBot {
     const answer = (msg) => sendMessage(msg, to, messageType)
     answer.broadcast = (msg) => _.forEach(rooms, room => sendMessage(msg, room.jid, 'groupchat'))
     try {
-      let result = command.command(answer, args, this.commandState[commandName], this.commandState)
+      let result = command(answer, args, this.commandState[commandName], this.commandState)
       if (result) {
         answer(result)
       }


### PR DESCRIPTION
There were error messages if i tried to use 

```
// register a command
bot.command('test', (answer, args, state, env) => {
    console.log("test commando triggered!")
    return "blabla"
})

bot.command('echo', (answer, args) => args.join(' '))
```
The changes fix the issue and the client responds correctly again :-)